### PR TITLE
add POST /subscriptions/digital-event endpoint

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -13,3 +13,27 @@ export const UserResponse = Type.Object({
   educationalLevel: Type.Optional(Type.String()),
   profession: Type.Optional(Type.String()),
 });
+
+export const ResourceRequest = Type.Object({
+  resourceType: Type.Union([
+    Type.Literal("subscriptions"),
+    Type.Literal("alacarte"),
+    Type.Literal("renewal"),
+  ]),
+  resource_type: Type.Optional(
+    Type.Union([
+      Type.Literal("subscriptions"),
+      Type.Literal("alacarte"),
+      Type.Literal("renewal"),
+    ]),
+  ),
+  resource: Type.Union([
+    Type.Literal("digitalEvent"),
+    Type.Literal("onsiteEvent"),
+    Type.Literal("phoneEvent"),
+    Type.Literal("groupEvent"),
+    Type.Literal("phoneEventIntake"),
+  ]),
+  resourceId: Type.Number(),
+  resource_id: Type.Optional(Type.Number()),
+});

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -14,6 +14,16 @@ export const UserResponse = Type.Object({
   profession: Type.Optional(Type.String()),
 });
 
+export const TokenResponse = Type.Object({
+  token: Type.String(),
+  user: UserResponse,
+  authType: Type.Union([
+    Type.Literal("logIn"),
+    Type.Literal("signUp"),
+    Type.Literal("payment"),
+  ]),
+});
+
 export const ResourceRequest = Type.Object({
   resourceType: Type.Union([
     Type.Literal("subscriptions"),

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -6,7 +6,7 @@ import { isPossiblePhoneNumber } from "libphonenumber-js";
 import { sendVerificationCode } from "../../lib/auth";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { UserResponse } from "../../lib/schemas";
+import { TokenResponse } from "../../lib/schemas";
 
 // TODO: harden validation here
 const VerifyTokenBody = Type.Object({
@@ -27,12 +27,6 @@ const TokenBody = Type.Object({
   confirmation_code: Type.Optional(Type.String()),
   email: Type.Optional(Type.String({ format: "email" })),
   channel: Type.Union([Type.Literal("sms"), Type.Literal("email")]),
-});
-
-const TokenResponse = Type.Object({
-  token: Type.String(),
-  user: UserResponse,
-  authType: Type.Union([Type.Literal("logIn"), Type.Literal("signUp")]),
 });
 
 type VerifyTokenBody = Static<typeof VerifyTokenBody>;

--- a/src/routes/subscriptions/index.ts
+++ b/src/routes/subscriptions/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from "fastify";
+
+const subscriptionsRouter: FastifyPluginAsync = async (
+  fastify,
+  _,
+): Promise<void> => {
+  fastify.post("/digital-event", async (request) => {});
+};

--- a/src/routes/subscriptions/index.ts
+++ b/src/routes/subscriptions/index.ts
@@ -1,8 +1,42 @@
+import { Static } from "@sinclair/typebox";
 import { FastifyPluginAsync } from "fastify";
+import { ResourceRequest, TokenResponse } from "../../lib/schemas";
+
+type DigitalEventRequestBody = Static<typeof ResourceRequest>;
 
 const subscriptionsRouter: FastifyPluginAsync = async (
   fastify,
-  _,
 ): Promise<void> => {
-  fastify.post("/digital-event", async (request) => {});
+  // FIXME: this was a stop gap for handling digital modules
+  fastify.post<{ Body: DigitalEventRequestBody }>(
+    "/digital-event",
+    {
+      schema: { body: ResourceRequest, response: { 200: TokenResponse } },
+      onRequest: fastify.authenticate,
+    },
+    async (request, reply) => {
+      if (request.body.resource !== "digitalEvent") {
+        throw fastify.httpErrors.badRequest(
+          'The only accepted value for resource is "digitalEvent"',
+        );
+      }
+
+      const token = await reply.jwtSign(
+        {
+          // @ts-ignore
+          sub: request.user.sub,
+          resourceType: request.body.resourceType ?? request.body.resource_type,
+          resource: request.body.resource,
+          resourceId: request.body.resourceId ?? request.body.resource_id,
+        },
+        { expiresIn: "60 days", algorithm: "HS256" },
+      );
+
+      return {
+        token,
+        user: null,
+        authType: "payment",
+      };
+    },
+  );
 };


### PR DESCRIPTION
- add schema and skeleton for /digital-event
- move tokenresponse schema to common export and add stubs for /digital-event
- create default export and ensure that the user is returned
