### PR TITLE
drop legacy unused tables

### DIFF
--- a/src/database/0004_clean_warbound.sql
+++ b/src/database/0004_clean_warbound.sql
@@ -1,0 +1,12 @@
+DROP TABLE "coachingSession";--> statement-breakpoint
+DROP TABLE "enterpriseStandard";--> statement-breakpoint
+DROP TABLE "fitnessClass";--> statement-breakpoint
+DROP TABLE "gymPass";--> statement-breakpoint
+DROP TABLE "individualBasic";--> statement-breakpoint
+DROP TABLE "joinShamiri";--> statement-breakpoint
+DROP TABLE "organization";--> statement-breakpoint
+DROP TABLE "provider";--> statement-breakpoint
+DROP TABLE "providerSession";--> statement-breakpoint
+DROP TABLE "teamAdmin";--> statement-breakpoint
+DROP TABLE "Tip";--> statement-breakpoint
+DROP TABLE "wellnessEvent";

--- a/src/database/meta/0004_snapshot.json
+++ b/src/database/meta/0004_snapshot.json
@@ -1,0 +1,4493 @@
+{
+  "id": "65acb80b-e315-4a16-bcb5-349e145ad687",
+  "prevId": "2790f7da-89d0-4015-98ef-6174587309dd",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "admin": {
+      "name": "admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_id_human_id_fk": {
+          "name": "admin_id_human_id_fk",
+          "tableFrom": "admin",
+          "tableTo": "human",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "affirmation": {
+      "name": "affirmation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_file_name": {
+          "name": "background_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "affirmation_userId_user_id_fk": {
+          "name": "affirmation_userId_user_id_fk",
+          "tableFrom": "affirmation",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "affirmation_of_the_day": {
+      "name": "affirmation_of_the_day",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_category": {
+          "name": "sub_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affirmation": {
+          "name": "affirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "affirmation_of_the_day_user_id_user_id_fk": {
+          "name": "affirmation_of_the_day_user_id_user_id_fk",
+          "tableFrom": "affirmation_of_the_day",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "affirmation_reminder": {
+      "name": "affirmation_reminder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_times": {
+          "name": "number_of_times",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "affirmation_reminder_user_id_user_id_fk": {
+          "name": "affirmation_reminder_user_id_user_id_fk",
+          "tableFrom": "affirmation_reminder",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "alacarteOrder": {
+      "name": "alacarteOrder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceId": {
+          "name": "insuranceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alacarteOrder_id_order_id_fk": {
+          "name": "alacarteOrder_id_order_id_fk",
+          "tableFrom": "alacarteOrder",
+          "tableTo": "order",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alacarteOrder_userId_user_id_fk": {
+          "name": "alacarteOrder_userId_user_id_fk",
+          "tableFrom": "alacarteOrder",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alacarteOrder_insuranceId_insurance_id_fk": {
+          "name": "alacarteOrder_insuranceId_insurance_id_fk",
+          "tableFrom": "alacarteOrder",
+          "tableTo": "insurance",
+          "columnsFrom": ["insuranceId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "alembic_version": {
+      "name": "alembic_version",
+      "schema": "",
+      "columns": {
+        "version_num": {
+          "name": "version_num",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "answers": {
+      "name": "answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "answers_questionId_questions_id_fk": {
+          "name": "answers_questionId_questions_id_fk",
+          "tableFrom": "answers",
+          "tableTo": "questions",
+          "columnsFrom": ["questionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "blacklistToken": {
+      "name": "blacklistToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blacklistedOn": {
+          "name": "blacklistedOn",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklistToken_token_key": {
+          "name": "blacklistToken_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      }
+    },
+    "calendar": {
+      "name": "calendar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Africa/Nairobi'::character varying"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_googleId_key": {
+          "name": "calendar_googleId_key",
+          "nullsNotDistinct": false,
+          "columns": ["googleId"]
+        }
+      }
+    },
+    "cbtCourse": {
+      "name": "cbtCourse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modulesString": {
+          "name": "modulesString",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedDomains": {
+          "name": "relatedDomains",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "about": {
+          "name": "about",
+          "type": "varchar(1500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetUrl": {
+          "name": "assetUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rgba(67, 143, 120, 0.1)'"
+        },
+        "buttonColor": {
+          "name": "buttonColor",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rgba(67, 143, 120)'::character varying"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "cbtEvent": {
+      "name": "cbtEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userModule": {
+          "name": "userModule",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cbtCourseId": {
+          "name": "cbtCourseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userProgress": {
+          "name": "userProgress",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cbtEvent_id_therapySession_id_fk": {
+          "name": "cbtEvent_id_therapySession_id_fk",
+          "tableFrom": "cbtEvent",
+          "tableTo": "therapySession",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cbtEvent_cbtCourseId_cbtCourse_id_fk": {
+          "name": "cbtEvent_cbtCourseId_cbtCourse_id_fk",
+          "tableFrom": "cbtEvent",
+          "tableTo": "cbtCourse",
+          "columnsFrom": ["cbtCourseId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "cbtModule": {
+      "name": "cbtModule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cbtCourseId": {
+          "name": "cbtCourseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "about": {
+          "name": "about",
+          "type": "varchar(1500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetUrl": {
+          "name": "assetUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cbtModule_cbtCourseId_cbtCourse_id_fk": {
+          "name": "cbtModule_cbtCourseId_cbtCourse_id_fk",
+          "tableFrom": "cbtModule",
+          "tableTo": "cbtCourse",
+          "columnsFrom": ["cbtCourseId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "cbtTopic": {
+      "name": "cbtTopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cbtModuleId": {
+          "name": "cbtModuleId",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cbtTopic_cbtModuleId_cbtModule_id_fk": {
+          "name": "cbtTopic_cbtModuleId_cbtModule_id_fk",
+          "tableFrom": "cbtTopic",
+          "tableTo": "cbtModule",
+          "columnsFrom": ["cbtModuleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_userId_user_id_fk": {
+          "name": "chat_userId_user_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "chatEvent": {
+      "name": "chatEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile": {
+          "name": "mobile",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataPrivacyString": {
+          "name": "dataPrivacyString",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chatEvent_id_therapySession_id_fk": {
+          "name": "chatEvent_id_therapySession_id_fk",
+          "tableFrom": "chatEvent",
+          "tableTo": "therapySession",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chatEvent_therapistId_therapist_id_fk": {
+          "name": "chatEvent_therapistId_therapist_id_fk",
+          "tableFrom": "chatEvent",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "client": {
+      "name": "client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "companyName": {
+          "name": "companyName",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "industry": {
+          "name": "industry",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contactEmail": {
+          "name": "contactEmail",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "KRAPin": {
+          "name": "KRAPin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nEmployees": {
+          "name": "nEmployees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "client_companyName_key": {
+          "name": "client_companyName_key",
+          "nullsNotDistinct": false,
+          "columns": ["companyName"]
+        },
+        "client_label_key": {
+          "name": "client_label_key",
+          "nullsNotDistinct": false,
+          "columns": ["label"]
+        },
+        "client_KRAPin_key": {
+          "name": "client_KRAPin_key",
+          "nullsNotDistinct": false,
+          "columns": ["KRAPin"]
+        }
+      }
+    },
+    "daily_check_in": {
+      "name": "daily_check_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "how_are_you_feeling": {
+          "name": "how_are_you_feeling",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description": {
+          "name": "mood_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_category_1": {
+          "name": "mood_description_cause_category_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_response_1": {
+          "name": "mood_description_cause_response_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_category_2": {
+          "name": "mood_description_cause_category_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_response_2": {
+          "name": "mood_description_cause_response_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_category_3": {
+          "name": "mood_description_cause_category_3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_description_cause_response_3": {
+          "name": "mood_description_cause_response_3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_check_in_user_id_user_id_fk": {
+          "name": "daily_check_in_user_id_user_id_fk",
+          "tableFrom": "daily_check_in",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "discountCode": {
+      "name": "discountCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelAgentRef": {
+          "name": "channelAgentRef",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeStamp": {
+          "name": "timeStamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completeDateTime": {
+          "name": "completeDateTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discountCode_orderId_order_id_fk": {
+          "name": "discountCode_orderId_order_id_fk",
+          "tableFrom": "discountCode",
+          "tableTo": "order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "favourited_affirmation": {
+      "name": "favourited_affirmation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favourited_affirmation_user_id_user_id_fk": {
+          "name": "favourited_affirmation_user_id_user_id_fk",
+          "tableFrom": "favourited_affirmation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "friendRequest": {
+      "name": "friendRequest",
+      "schema": "",
+      "columns": {
+        "initiatorId": {
+          "name": "initiatorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendRequest_initiatorId_user_id_fk": {
+          "name": "friendRequest_initiatorId_user_id_fk",
+          "tableFrom": "friendRequest",
+          "tableTo": "user",
+          "columnsFrom": ["initiatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "friendRequest_targetId_user_id_fk": {
+          "name": "friendRequest_targetId_user_id_fk",
+          "tableFrom": "friendRequest",
+          "tableTo": "user",
+          "columnsFrom": ["targetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendRequest_pkey": {
+          "name": "friendRequest_pkey",
+          "columns": ["initiatorId", "targetId"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "leftId": {
+          "name": "leftId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rightId": {
+          "name": "rightId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_leftId_user_id_fk": {
+          "name": "friendship_leftId_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": ["leftId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "friendship_rightId_user_id_fk": {
+          "name": "friendship_rightId_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": ["rightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendship_pkey": {
+          "name": "friendship_pkey",
+          "columns": ["leftId", "rightId"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "goal_category": {
+      "name": "goal_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_image_colour": {
+          "name": "background_image_colour",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_image_name": {
+          "name": "background_image_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_category_user_id_user_id_fk": {
+          "name": "goal_category_user_id_user_id_fk",
+          "tableFrom": "goal_category",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "goal_progress": {
+      "name": "goal_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_progress_goal_id_goals_id_fk": {
+          "name": "goal_progress_goal_id_goals_id_fk",
+          "tableFrom": "goal_progress",
+          "tableTo": "goals",
+          "columnsFrom": ["goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_start": {
+          "name": "duration_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_end": {
+          "name": "duration_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_frequency": {
+          "name": "weekly_frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_for_goal": {
+          "name": "reason_for_goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_goal_id": {
+          "name": "parent_goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_category_id": {
+          "name": "goal_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_user_id_fk": {
+          "name": "goals_user_id_user_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_goal_category_id_goal_category_id_fk": {
+          "name": "goals_goal_category_id_goal_category_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "goal_category",
+          "columnsFrom": ["goal_category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "goals_parent_goal_id_fkey": {
+          "name": "goals_parent_goal_id_fkey",
+          "tableFrom": "goals",
+          "tableTo": "goals",
+          "columnsFrom": ["parent_goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groupEvent": {
+      "name": "groupEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Africa/Nairobi'::character varying"
+        },
+        "groupTopicId": {
+          "name": "groupTopicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupSessionId": {
+          "name": "groupSessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groupEvent_id_therapySession_id_fk": {
+          "name": "groupEvent_id_therapySession_id_fk",
+          "tableFrom": "groupEvent",
+          "tableTo": "therapySession",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "groupEvent_groupTopicId_groupTopic_id_fk": {
+          "name": "groupEvent_groupTopicId_groupTopic_id_fk",
+          "tableFrom": "groupEvent",
+          "tableTo": "groupTopic",
+          "columnsFrom": ["groupTopicId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupEvent_groupSessionId_groupSession_id_fk": {
+          "name": "groupEvent_groupSessionId_groupSession_id_fk",
+          "tableFrom": "groupEvent",
+          "tableTo": "groupSession",
+          "columnsFrom": ["groupSessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groupPlan": {
+      "name": "groupPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phoneEventCredits": {
+          "name": "phoneEventCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupEventCredits": {
+          "name": "groupEventCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onsiteEventCredits": {
+          "name": "onsiteEventCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expireTime": {
+          "name": "expireTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groupPlan_clientId_client_id_fk": {
+          "name": "groupPlan_clientId_client_id_fk",
+          "tableFrom": "groupPlan",
+          "tableTo": "client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groupPlanOrder": {
+      "name": "groupPlanOrder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupPlanId": {
+          "name": "groupPlanId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groupPlanOrder_id_order_id_fk": {
+          "name": "groupPlanOrder_id_order_id_fk",
+          "tableFrom": "groupPlanOrder",
+          "tableTo": "order",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupPlanOrder_groupPlanId_groupPlan_id_fk": {
+          "name": "groupPlanOrder_groupPlanId_groupPlan_id_fk",
+          "tableFrom": "groupPlanOrder",
+          "tableTo": "groupPlan",
+          "columnsFrom": ["groupPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupPlanOrder_userId_user_id_fk": {
+          "name": "groupPlanOrder_userId_user_id_fk",
+          "tableFrom": "groupPlanOrder",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groupSession": {
+      "name": "groupSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "groupTopicId": {
+          "name": "groupTopicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordLink": {
+          "name": "discordLink",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 15
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groupSession_therapistId_therapist_id_fk": {
+          "name": "groupSession_therapistId_therapist_id_fk",
+          "tableFrom": "groupSession",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupSession_groupTopicId_groupTopic_id_fk": {
+          "name": "groupSession_groupTopicId_groupTopic_id_fk",
+          "tableFrom": "groupSession",
+          "tableTo": "groupTopic",
+          "columnsFrom": ["groupTopicId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groupTopic": {
+      "name": "groupTopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "about": {
+          "name": "about",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedDomains": {
+          "name": "relatedDomains",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttonColor": {
+          "name": "buttonColor",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetUrl": {
+          "name": "assetUrl",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "human": {
+      "name": "human",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile": {
+          "name": "mobile",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLogin": {
+          "name": "lastLogin",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "human_email_key": {
+          "name": "human_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "mobile_unique": {
+          "name": "mobile_unique",
+          "nullsNotDistinct": false,
+          "columns": ["mobile"]
+        }
+      }
+    },
+    "insurance": {
+      "name": "insurance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "underwriter": {
+          "name": "underwriter",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "underwriterRef": {
+          "name": "underwriterRef",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "insurance_userId_user_id_fk": {
+          "name": "insurance_userId_user_id_fk",
+          "tableFrom": "insurance",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_userId_key": {
+          "name": "insurance_userId_key",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        }
+      }
+    },
+    "journal": {
+      "name": "journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_1": {
+          "name": "question_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_1": {
+          "name": "content_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_2": {
+          "name": "question_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_2": {
+          "name": "content_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_3": {
+          "name": "question_3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_3": {
+          "name": "content_3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_userId_user_id_fk": {
+          "name": "journal_userId_user_id_fk",
+          "tableFrom": "journal",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'assistant'::character varying"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_chatId_chat_id_fk": {
+          "name": "message_chatId_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "onsiteEvent": {
+      "name": "onsiteEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataPrivacyString": {
+          "name": "dataPrivacyString",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "onsiteEvent_id_therapySession_id_fk": {
+          "name": "onsiteEvent_id_therapySession_id_fk",
+          "tableFrom": "onsiteEvent",
+          "tableTo": "therapySession",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onsiteEvent_therapistId_therapist_id_fk": {
+          "name": "onsiteEvent_therapistId_therapist_id_fk",
+          "tableFrom": "onsiteEvent",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unitPrice": {
+          "name": "unitPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completeTimestamp": {
+          "name": "completeTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentMethod": {
+          "name": "paymentMethod",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentRef": {
+          "name": "paymentRef",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentNote": {
+          "name": "paymentNote",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'subscriptionOrder'::character varying"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_paymentRef_key": {
+          "name": "order_paymentRef_key",
+          "nullsNotDistinct": false,
+          "columns": ["paymentRef"]
+        }
+      }
+    },
+    "phoneEvent": {
+      "name": "phoneEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 205
+        },
+        "googleTherapistEventId": {
+          "name": "googleTherapistEventId",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Africa/Nairobi'::character varying"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile": {
+          "name": "mobile",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataPrivacyString": {
+          "name": "dataPrivacyString",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phoneEvent_id_therapySession_id_fk": {
+          "name": "phoneEvent_id_therapySession_id_fk",
+          "tableFrom": "phoneEvent",
+          "tableTo": "therapySession",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phoneEvent_therapistId_therapist_id_fk": {
+          "name": "phoneEvent_therapistId_therapist_id_fk",
+          "tableFrom": "phoneEvent",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phoneEvent_googleTherapistEventId_key": {
+          "name": "phoneEvent_googleTherapistEventId_key",
+          "nullsNotDistinct": false,
+          "columns": ["googleTherapistEventId"]
+        }
+      }
+    },
+    "questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_therapistId_therapist_id_fk": {
+          "name": "questions_therapistId_therapist_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "quickReplies": {
+      "name": "quickReplies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quickReplies_id_userResponse_id_fk": {
+          "name": "quickReplies_id_userResponse_id_fk",
+          "tableFrom": "quickReplies",
+          "tableTo": "userResponse",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referral_codes_client_id_client_id_fk": {
+          "name": "referral_codes_client_id_client_id_fk",
+          "tableFrom": "referral_codes",
+          "tableTo": "client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referral_codes_email_key": {
+          "name": "referral_codes_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "unique_email_referral_code_combination": {
+          "name": "unique_email_referral_code_combination",
+          "nullsNotDistinct": false,
+          "columns": ["email", "referral_code"]
+        },
+        "referral_codes_referral_code_key": {
+          "name": "referral_codes_referral_code_key",
+          "nullsNotDistinct": false,
+          "columns": ["referral_code"]
+        }
+      }
+    },
+    "rewardHubRecord": {
+      "name": "rewardHubRecord",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userRewardHubId": {
+          "name": "userRewardHubId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "levelName": {
+          "name": "levelName",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemsHave": {
+          "name": "gemsHave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemsNextLevel": {
+          "name": "gemsNextLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewardHubRecord_userRewardHubId_userRewardHub_id_fk": {
+          "name": "rewardHubRecord_userRewardHubId_userRewardHub_id_fk",
+          "tableFrom": "rewardHubRecord",
+          "tableTo": "userRewardHub",
+          "columnsFrom": ["userRewardHubId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "shamiriScore": {
+      "name": "shamiriScore",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userDisplayId": {
+          "name": "userDisplayId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shamiriScore_userDisplayId_userDisplay_id_fk": {
+          "name": "shamiriScore_userDisplayId_userDisplay_id_fk",
+          "tableFrom": "shamiriScore",
+          "tableTo": "userDisplay",
+          "columnsFrom": ["userDisplayId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expireTime": {
+          "name": "expireTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalCredit": {
+          "name": "totalCredit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remCredit": {
+          "name": "remCredit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_userId_user_id_fk": {
+          "name": "subscription_userId_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "subscriptionOrder": {
+      "name": "subscriptionOrder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionType": {
+          "name": "subscriptionType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionNow": {
+          "name": "actionNow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptionOrder_id_order_id_fk": {
+          "name": "subscriptionOrder_id_order_id_fk",
+          "tableFrom": "subscriptionOrder",
+          "tableTo": "order",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptionOrder_userId_user_id_fk": {
+          "name": "subscriptionOrder_userId_user_id_fk",
+          "tableFrom": "subscriptionOrder",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptionOrder_subscriptionId_subscription_id_fk": {
+          "name": "subscriptionOrder_subscriptionId_subscription_id_fk",
+          "tableFrom": "subscriptionOrder",
+          "tableTo": "subscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "systemResponse": {
+      "name": "systemResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "responseId": {
+          "name": "responseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measure": {
+          "name": "measure",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measureShortName": {
+          "name": "measureShortName",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay": {
+          "name": "delay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable": {
+          "name": "variable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "altText1": {
+          "name": "altText1",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "altText2": {
+          "name": "altText2",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "altText3": {
+          "name": "altText3",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "altText4": {
+          "name": "altText4",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wellbeing": {
+          "name": "wellbeing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "satisfaction": {
+          "name": "satisfaction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewardHubActions": {
+          "name": "rewardHubActions",
+          "type": "json[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "teletherapyOrder": {
+      "name": "teletherapyOrder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "therapySessionType": {
+          "name": "therapySessionType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phoneEvent'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teletherapyOrder_id_order_id_fk": {
+          "name": "teletherapyOrder_id_order_id_fk",
+          "tableFrom": "teletherapyOrder",
+          "tableTo": "order",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teletherapyOrder_userId_user_id_fk": {
+          "name": "teletherapyOrder_userId_user_id_fk",
+          "tableFrom": "teletherapyOrder",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "text": {
+      "name": "text",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "text_id_userResponse_id_fk": {
+          "name": "text_id_userResponse_id_fk",
+          "tableFrom": "text",
+          "tableTo": "userResponse",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "therapist": {
+      "name": "therapist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "photoUrl": {
+          "name": "photoUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dateOfBirth": {
+          "name": "dateOfBirth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "about": {
+          "name": "about",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail": {
+          "name": "gmail",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinicalLevel": {
+          "name": "clinicalLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workingTimeStart": {
+          "name": "workingTimeStart",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workingTimeEnd": {
+          "name": "workingTimeEnd",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialtyTags": {
+          "name": "specialtyTags",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportPhone": {
+          "name": "supportPhone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportInPerson": {
+          "name": "supportInPerson",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "therapist_id_human_id_fk": {
+          "name": "therapist_id_human_id_fk",
+          "tableFrom": "therapist",
+          "tableTo": "human",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "therapist_client_id_client_id_fk": {
+          "name": "therapist_client_id_client_id_fk",
+          "tableFrom": "therapist",
+          "tableTo": "client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "therapistCal": {
+      "name": "therapistCal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "therapistId": {
+          "name": "therapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "therapistCal_id_calendar_id_fk": {
+          "name": "therapistCal_id_calendar_id_fk",
+          "tableFrom": "therapistCal",
+          "tableTo": "calendar",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "therapistCal_therapistId_therapist_id_fk": {
+          "name": "therapistCal_therapistId_therapist_id_fk",
+          "tableFrom": "therapistCal",
+          "tableTo": "therapist",
+          "columnsFrom": ["therapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "therapistCal_therapistId_key": {
+          "name": "therapistCal_therapistId_key",
+          "nullsNotDistinct": false,
+          "columns": ["therapistId"]
+        }
+      }
+    },
+    "therapySession": {
+      "name": "therapySession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinicalLevel": {
+          "name": "clinicalLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedDomains": {
+          "name": "relatedDomains",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendDatetime": {
+          "name": "recommendDatetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completeDatetime": {
+          "name": "completeDatetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollDatetime": {
+          "name": "enrollDatetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit": {
+          "name": "credit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userRecordId": {
+          "name": "userRecordId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "therapySession_userRecordId_userRecord_id_fk": {
+          "name": "therapySession_userRecordId_userRecord_id_fk",
+          "tableFrom": "therapySession",
+          "tableTo": "userRecord",
+          "columnsFrom": ["userRecordId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registeredOn": {
+          "name": "registeredOn",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dateOfBirth": {
+          "name": "dateOfBirth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarId": {
+          "name": "avatarId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rafibot": {
+          "name": "rafibot",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edLevel": {
+          "name": "edLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marStatus": {
+          "name": "marStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orgLevel": {
+          "name": "orgLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workingTimeStart": {
+          "name": "workingTimeStart",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workingTimeEnd": {
+          "name": "workingTimeEnd",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Africa/Nairobi'"
+        },
+        "gender2": {
+          "name": "gender2",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maritalStatus": {
+          "name": "maritalStatus",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationalLevel": {
+          "name": "organizationalLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "educationalLevel": {
+          "name": "educationalLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinH": {
+          "name": "pinH",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profession": {
+          "name": "profession",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_record_id": {
+          "name": "referral_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_human_id_fk": {
+          "name": "user_id_human_id_fk",
+          "tableFrom": "user",
+          "tableTo": "human",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_clientId_client_id_fk": {
+          "name": "user_clientId_client_id_fk",
+          "tableFrom": "user",
+          "tableTo": "client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_referral_record_id_referral_codes_id_fk": {
+          "name": "user_referral_record_id_referral_codes_id_fk",
+          "tableFrom": "user",
+          "tableTo": "referral_codes",
+          "columnsFrom": ["referral_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_alias_key": {
+          "name": "user_alias_key",
+          "nullsNotDistinct": false,
+          "columns": ["alias"]
+        }
+      }
+    },
+    "userAchievement": {
+      "name": "userAchievement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userRewardHubId": {
+          "name": "userRewardHubId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak1": {
+          "name": "achStreak1",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak2": {
+          "name": "achStreak2",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak3": {
+          "name": "achStreak3",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak4": {
+          "name": "achStreak4",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak5": {
+          "name": "achStreak5",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achStreak6": {
+          "name": "achStreak6",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin1": {
+          "name": "achCheckin1",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin2": {
+          "name": "achCheckin2",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin3": {
+          "name": "achCheckin3",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin4": {
+          "name": "achCheckin4",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin5": {
+          "name": "achCheckin5",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achCheckin6": {
+          "name": "achCheckin6",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel1": {
+          "name": "achLevel1",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel2": {
+          "name": "achLevel2",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel3": {
+          "name": "achLevel3",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel4": {
+          "name": "achLevel4",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel5": {
+          "name": "achLevel5",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel6": {
+          "name": "achLevel6",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel7": {
+          "name": "achLevel7",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel8": {
+          "name": "achLevel8",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel9": {
+          "name": "achLevel9",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achLevel10": {
+          "name": "achLevel10",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gems": {
+          "name": "gems",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_updated_at": {
+          "name": "streak_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userAchievement_userRewardHubId_userRewardHub_id_fk": {
+          "name": "userAchievement_userRewardHubId_userRewardHub_id_fk",
+          "tableFrom": "userAchievement",
+          "tableTo": "userRewardHub",
+          "columnsFrom": ["userRewardHubId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "userAchievement_user_id_user_id_fk": {
+          "name": "userAchievement_user_id_user_id_fk",
+          "tableFrom": "userAchievement",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userBaselineRecord": {
+      "name": "userBaselineRecord",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ed_level": {
+          "name": "ed_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal1Id": {
+          "name": "goal1Id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal2Id": {
+          "name": "goal2Id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gad2_1": {
+          "name": "gad2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gad2_2": {
+          "name": "gad2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_1": {
+          "name": "ghq12_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_10": {
+          "name": "ghq12_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_11": {
+          "name": "ghq12_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_12": {
+          "name": "ghq12_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_2": {
+          "name": "ghq12_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_3": {
+          "name": "ghq12_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_4": {
+          "name": "ghq12_4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_5": {
+          "name": "ghq12_5",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_6": {
+          "name": "ghq12_6",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_7": {
+          "name": "ghq12_7",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_8": {
+          "name": "ghq12_8",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq12_9": {
+          "name": "ghq12_9",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phq2_1": {
+          "name": "phq2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phq2_2": {
+          "name": "phq2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_1_1": {
+          "name": "shamiri_1_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_1_2": {
+          "name": "shamiri_1_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_2_1": {
+          "name": "shamiri_2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_2_2": {
+          "name": "shamiri_2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_3_1": {
+          "name": "shamiri_3_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_3_2": {
+          "name": "shamiri_3_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_4_1": {
+          "name": "shamiri_4_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_4_2": {
+          "name": "shamiri_4_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_5_1": {
+          "name": "shamiri_5_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_5_2": {
+          "name": "shamiri_5_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiriIndex": {
+          "name": "shamiriIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq8Index": {
+          "name": "ghq8Index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userBaselineRecord_id_userRecord_id_fk": {
+          "name": "userBaselineRecord_id_userRecord_id_fk",
+          "tableFrom": "userBaselineRecord",
+          "tableTo": "userRecord",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userCheckinRecord": {
+      "name": "userCheckinRecord",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gad2_1": {
+          "name": "gad2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gad2_2": {
+          "name": "gad2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gadphq2_f": {
+          "name": "gadphq2_f",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_1_1": {
+          "name": "ghq4_1_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_1_2": {
+          "name": "ghq4_1_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_1_3": {
+          "name": "ghq4_1_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_1_9": {
+          "name": "ghq4_1_9",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_2_10": {
+          "name": "ghq4_2_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_2_12": {
+          "name": "ghq4_2_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_2_4": {
+          "name": "ghq4_2_4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_2_6": {
+          "name": "ghq4_2_6",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_3_11": {
+          "name": "ghq4_3_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_3_5": {
+          "name": "ghq4_3_5",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_3_7": {
+          "name": "ghq4_3_7",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghq4_3_8": {
+          "name": "ghq4_3_8",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_1": {
+          "name": "mspss_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_10": {
+          "name": "mspss_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_11": {
+          "name": "mspss_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_12": {
+          "name": "mspss_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_2": {
+          "name": "mspss_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_3": {
+          "name": "mspss_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_4": {
+          "name": "mspss_4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_5": {
+          "name": "mspss_5",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_6": {
+          "name": "mspss_6",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_7": {
+          "name": "mspss_7",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_8": {
+          "name": "mspss_8",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mspss_9": {
+          "name": "mspss_9",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phq2_1": {
+          "name": "phq2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phq2_2": {
+          "name": "phq2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pils4_1": {
+          "name": "pils4_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pils4_2": {
+          "name": "pils4_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pils4_3": {
+          "name": "pils4_3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pils4_4": {
+          "name": "pils4_4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_1_1": {
+          "name": "shamiri_1_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_1_2": {
+          "name": "shamiri_1_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_2_1": {
+          "name": "shamiri_2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_2_2": {
+          "name": "shamiri_2_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_3_1": {
+          "name": "shamiri_3_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_3_2": {
+          "name": "shamiri_3_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_4_1": {
+          "name": "shamiri_4_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_4_2": {
+          "name": "shamiri_4_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_5_1": {
+          "name": "shamiri_5_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shamiri_5_2": {
+          "name": "shamiri_5_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "satisfaction_sha_2_1": {
+          "name": "satisfaction_sha_2_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation_pils4_4": {
+          "name": "motivation_pils4_4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCheckinRecord_id_userRecord_id_fk": {
+          "name": "userCheckinRecord_id_userRecord_id_fk",
+          "tableFrom": "userCheckinRecord",
+          "tableTo": "userRecord",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userDisplay": {
+      "name": "userDisplay",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wellbeing": {
+          "name": "wellbeing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "satisfaction": {
+          "name": "satisfaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social": {
+          "name": "social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dateTime": {
+          "name": "dateTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userRecordId": {
+          "name": "userRecordId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dalleRef": {
+          "name": "dalleRef",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverStreamId": {
+          "name": "discoverStreamId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userDisplay_userId_user_id_fk": {
+          "name": "userDisplay_userId_user_id_fk",
+          "tableFrom": "userDisplay",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "userDisplay_userRecordId_userRecord_id_fk": {
+          "name": "userDisplay_userRecordId_userRecord_id_fk",
+          "tableFrom": "userDisplay",
+          "tableTo": "userRecord",
+          "columnsFrom": ["userRecordId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userDisplay_streamId_key": {
+          "name": "userDisplay_streamId_key",
+          "nullsNotDistinct": false,
+          "columns": ["streamId"]
+        },
+        "userDisplay_discoverStreamId_key": {
+          "name": "userDisplay_discoverStreamId_key",
+          "nullsNotDistinct": false,
+          "columns": ["discoverStreamId"]
+        }
+      }
+    },
+    "userGoal": {
+      "name": "userGoal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userRewardHubId": {
+          "name": "userRewardHubId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal1Id": {
+          "name": "goal1Id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal2Id": {
+          "name": "goal2Id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal1Timeframe": {
+          "name": "goal1Timeframe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal1Scale": {
+          "name": "goal1Scale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal2Timeframe": {
+          "name": "goal2Timeframe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal2Scale": {
+          "name": "goal2Scale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal1Baseline": {
+          "name": "goal1Baseline",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal2Baseline": {
+          "name": "goal2Baseline",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userGoal_userRewardHubId_userRewardHub_id_fk": {
+          "name": "userGoal_userRewardHubId_userRewardHub_id_fk",
+          "tableFrom": "userGoal",
+          "tableTo": "userRewardHub",
+          "columnsFrom": ["userRewardHubId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userRecord": {
+      "name": "userRecord",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completeTimestamp": {
+          "name": "completeTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateId": {
+          "name": "stateId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'intake'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userRecord_userId_user_id_fk": {
+          "name": "userRecord_userId_user_id_fk",
+          "tableFrom": "userRecord",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userResponse": {
+      "name": "userResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "responseId": {
+          "name": "responseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseType": {
+          "name": "responseType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userRewardHub": {
+      "name": "userRewardHub",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gemsHave": {
+          "name": "gemsHave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userRewardHub_userId_user_id_fk": {
+          "name": "userRewardHub_userId_user_id_fk",
+          "tableFrom": "userRewardHub",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userService": {
+      "name": "userService",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationTime": {
+          "name": "notificationTime",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10:00 AM'::character varying"
+        },
+        "notificationOn": {
+          "name": "notificationOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "notificationOn2": {
+          "name": "notificationOn2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "notificationTime2": {
+          "name": "notificationTime2",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10:00 AM'"
+        },
+        "assignedTherapistId": {
+          "name": "assignedTherapistId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 205
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userService_userId_user_id_fk": {
+          "name": "userService_userId_user_id_fk",
+          "tableFrom": "userService",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "userService_assignedTherapistId_therapist_id_fk": {
+          "name": "userService_assignedTherapistId_therapist_id_fk",
+          "tableFrom": "userService",
+          "tableTo": "therapist",
+          "columnsFrom": ["assignedTherapistId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "userSystemResponse": {
+      "name": "userSystemResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "systemResponse_id": {
+          "name": "systemResponse_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userResponse_id": {
+          "name": "userResponse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSystemResponse_systemResponse_id_systemResponse_id_fk": {
+          "name": "userSystemResponse_systemResponse_id_systemResponse_id_fk",
+          "tableFrom": "userSystemResponse",
+          "tableTo": "systemResponse",
+          "columnsFrom": ["systemResponse_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "userSystemResponse_userResponse_id_userResponse_id_fk": {
+          "name": "userSystemResponse_userResponse_id_userResponse_id_fk",
+          "tableFrom": "userSystemResponse",
+          "tableTo": "userResponse",
+          "columnsFrom": ["userResponse_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/database/meta/_journal.json
+++ b/src/database/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1709544804492,
       "tag": "0003_sloppy_boomerang",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1714478250452,
+      "tag": "0004_clean_warbound",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -238,13 +238,6 @@ export const discountCode = pgTable("discountCode", {
   ref: varchar("ref", { length: 100 }),
 });
 
-export const fitnessClass = pgTable("fitnessClass", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => providerSession.id),
-});
-
 export const dailyCheckIn = pgTable("daily_check_in", {
   id: dbText("id"),
   createdAt: timestamp("created_at", { mode: "date" }),
@@ -258,14 +251,6 @@ export const dailyCheckIn = pgTable("daily_check_in", {
   moodDescriptionCauseCategory3: dbText("mood_description_cause_category_3"),
   moodDescriptionCauseResponse3: dbText("mood_description_cause_response_3"),
   userId: integer("user_id").references(() => user.id),
-});
-
-export const enterpriseStandard = pgTable("enterpriseStandard", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => subscription.id),
-  clientId: integer("clientId").references(() => client.id),
 });
 
 export const favouritedAffirmation = pgTable("favourited_affirmation", {
@@ -398,21 +383,6 @@ export const groupPlanOrder = pgTable("groupPlanOrder", {
   userId: integer("userId").references(() => user.id),
 });
 
-export const gymPass = pgTable("gymPass", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => providerSession.id),
-});
-
-export const individualBasic = pgTable("individualBasic", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => subscription.id),
-  autoRenew: boolean("autoRenew"),
-});
-
 export const human = pgTable(
   "human",
   {
@@ -447,16 +417,6 @@ export const insurance = pgTable(
     };
   },
 );
-
-export const joinShamiri = pgTable("joinShamiri", {
-  id: serial("id").primaryKey().notNull(),
-  fullName: varchar("fullName", { length: 80 }),
-  organisationName: varchar("organisationName", { length: 120 }),
-  contactEmail: varchar("contactEmail", { length: 120 }),
-  homeCity: varchar("homeCity", { length: 120 }),
-  phoneNumber: varchar("phoneNumber", { length: 120 }),
-  note: varchar("note", { length: 120 }),
-});
 
 export const journal = pgTable("journal", {
   id: varchar("id", { length: 100 }).primaryKey().notNull(),
@@ -524,27 +484,6 @@ export const quickReplies = pgTable("quickReplies", {
   text: varchar("text", { length: 200 }).notNull(),
 });
 
-export const organization = pgTable(
-  "organization",
-  {
-    id: serial("id").primaryKey().notNull(),
-    role: varchar("role", { length: 50 }),
-    name: varchar("name", { length: 80 }),
-    email: varchar("email", { length: 400 }),
-    phone: varchar("phone", { length: 120 }),
-    location: varchar("location", { length: 6000 }),
-  },
-  (table) => {
-    return {
-      organizationEmailKey: unique("organization_email_key").on(table.email),
-      organizationPhoneKey: unique("organization_phone_key").on(table.phone),
-      organizationLocationKey: unique("organization_location_key").on(
-        table.location,
-      ),
-    };
-  },
-);
-
 export const referralCodes = pgTable(
   "referral_codes",
   {
@@ -580,18 +519,6 @@ export const message = pgTable("message", {
   role: varchar("role", { length: 20 })
     .default(sql`'assistant'::character varying`)
     .notNull(),
-});
-
-export const providerSession = pgTable("providerSession", {
-  id: serial("id").primaryKey().notNull(),
-  startTime: timestamp("startTime", { mode: "date" }),
-  endTime: timestamp("endTime", { mode: "date" }),
-  providerId: integer("providerId").references(() => provider.id),
-  capacity: integer("capacity"),
-  summary: varchar("summary", { length: 200 }),
-  about: varchar("about", { length: 1000 }),
-  credit: integer("credit"),
-  type: varchar("type", { length: 80 }),
 });
 
 export const order = pgTable(
@@ -680,27 +607,6 @@ export const subscription = pgTable("subscription", {
   ref: varchar("ref", { length: 100 }),
 });
 
-export const tip = pgTable(
-  "Tip",
-  {
-    id: serial("id").primaryKey().notNull(),
-    name: varchar("name", { length: 10 }),
-    text: varchar("text", { length: 4000 }),
-    summary: varchar("summary", { length: 500 }),
-    modifyDatetime: timestamp("modifyDatetime", { mode: "date" }),
-    frequency: doublePrecision("frequency"),
-    relatedGoal1: integer("relatedGoal1"),
-    relatedGoal2: integer("relatedGoal2"),
-  },
-  (table) => {
-    return {
-      tipNameKey: unique("Tip_name_key").on(table.name),
-      tipTextKey: unique("Tip_text_key").on(table.text),
-      tipSummaryKey: unique("Tip_summary_key").on(table.summary),
-    };
-  },
-);
-
 export const therapySession = pgTable("therapySession", {
   id: varchar("id", { length: 64 }).primaryKey().notNull(),
   userId: integer("userId").notNull(),
@@ -753,14 +659,6 @@ export const subscriptionOrder = pgTable("subscriptionOrder", {
   actionNow: boolean("actionNow").notNull(),
 });
 
-export const teamAdmin = pgTable("teamAdmin", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => human.id),
-  clientId: integer("clientId").references(() => client.id),
-});
-
 export const teletherapyOrder = pgTable("teletherapyOrder", {
   id: serial("id")
     .primaryKey()
@@ -806,13 +704,6 @@ export const systemResponse = pgTable("systemResponse", {
   motivation: boolean("motivation"),
   purpose: boolean("purpose"),
   rewardHubActions: json("rewardHubActions").array(),
-});
-
-export const coachingSession = pgTable("coachingSession", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => providerSession.id),
 });
 
 export const userAchievement = pgTable("userAchievement", {
@@ -1076,17 +967,6 @@ export const userService = pgTable("userService", {
     .references(() => therapist.id),
 });
 
-export const wellnessEvent = pgTable("wellnessEvent", {
-  id: varchar("id", { length: 64 }).primaryKey().notNull(),
-  userId: integer("userId").notNull(),
-  type: varchar("type", { length: 80 }),
-  providerId: integer("providerId").references(() => provider.id),
-  recommendDatetime: timestamp("recommendDatetime", { mode: "date" }),
-  completeDatetime: timestamp("completeDatetime", { mode: "date" }),
-  enrollDatetime: timestamp("enrollDatetime", { mode: "date" }),
-  providerSessionId: integer("providerSessionId").notNull(),
-});
-
 export const goalProgress = pgTable("goal_progress", {
   id: dbText("id").primaryKey().notNull(),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }),
@@ -1094,20 +974,6 @@ export const goalProgress = pgTable("goal_progress", {
   goalId: dbText("goal_id").references(() => goals.id, {
     onDelete: "set null",
   }),
-});
-
-export const provider = pgTable("provider", {
-  id: integer("id")
-    .primaryKey()
-    .notNull()
-    .references(() => organization.id),
-  photoUrl: varchar("photoUrl", { length: 500 }),
-  about: varchar("about", { length: 500 }),
-  summary: varchar("summary", { length: 100 }),
-  timeZone: varchar("timeZone", { length: 80 }),
-  workingTimeStart: varchar("workingTimeStart", { length: 15 }),
-  workingTimeEnd: varchar("workingTimeEnd", { length: 15 }),
-  type: varchar("type", { length: 80 }),
 });
 
 export const userResponse = pgTable("userResponse", {


### PR DESCRIPTION
The dropped tables are
1. coachingSession
2. enterpriseStandard
3. fitnessClass
4. gymPass
5. individualBasic
6. joinShamiri
7. organization
8. provider
9. providerSession
10. teamAdmin
11. tip
12. wellnessEvent
